### PR TITLE
Fix missing LLM response by adding API route and client fetch

### DIFF
--- a/src/app/api/llm/route.js
+++ b/src/app/api/llm/route.js
@@ -1,0 +1,33 @@
+export async function GET() {
+  const apiKey = process.env.OPENAI_API_KEY;
+
+  if (!apiKey) {
+    return Response.json({ message: 'No LLM configured' });
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        input: 'Say hello',
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text);
+    }
+
+    const data = await response.json();
+    const output = data.output_text || data.choices?.[0]?.message?.content || 'No output';
+    return Response.json({ message: output });
+  } catch (error) {
+    console.error('LLM error', error);
+    return Response.json({ error: 'LLM request failed' }, { status: 500 });
+  }
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,9 +1,28 @@
+"use client";
+
 import Image from "next/image";
+import { useEffect, useState } from "react";
 
 export default function Home() {
+  const [llmMessage, setLlmMessage] = useState("Waiting for LLM response...");
+
+  useEffect(() => {
+    async function fetchResponse() {
+      try {
+        const res = await fetch("/api/llm");
+        const data = await res.json();
+        setLlmMessage(data.message || data.error || "No response");
+      } catch {
+        setLlmMessage("Failed to load LLM response");
+      }
+    }
+    fetchResponse();
+  }, []);
+
   return (
     <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
+        <p>{llmMessage}</p>
         <Image
           className="dark:invert"
           src="/next.svg"


### PR DESCRIPTION
## Summary
- add API route that requests an LLM and returns a message
- fetch LLM response on the home page and display the result

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt, no lint results)*

------
https://chatgpt.com/codex/tasks/task_e_68981ce6b5d4832391e26c9fd26cab90